### PR TITLE
Add an extra LIBMYGPO_QT_ prefix on the include guards

### DIFF
--- a/src/AddRemoveResult.h
+++ b/src/AddRemoveResult.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef ADDREMOVERESULT_H
-#define ADDREMOVERESULT_H
+#ifndef LIBMYGPO_QT_ADDREMOVERESULT_H
+#define LIBMYGPO_QT_ADDREMOVERESULT_H
 
 #include <QList>
 #include <QVariant>
@@ -67,4 +67,4 @@ typedef QSharedPointer<AddRemoveResult> AddRemoveResultPtr;
 
 Q_DECLARE_METATYPE( mygpo::AddRemoveResultPtr );
 
-#endif // ADDREMOVERESULT_H
+#endif // LIBMYGPO_QT_ADDREMOVERESULT_H

--- a/src/ApiRequest.h
+++ b/src/ApiRequest.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef APIREQUEST_H
-#define APIREQUEST_H
+#ifndef LIBMYGPO_QT_APIREQUEST_H
+#define LIBMYGPO_QT_APIREQUEST_H
 
 #define MYGPO_MAJOR_VERSION 1
 #define MYGPO_MINOR_VERSION 0

--- a/src/Device.h
+++ b/src/Device.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef DEVICE_H
-#define DEVICE_H
+#ifndef LIBMYGPO_QT_DEVICE_H
+#define LIBMYGPO_QT_DEVICE_H
 
 #include "mygpo_export.h"
 
@@ -68,4 +68,4 @@ typedef QSharedPointer<Device> DevicePtr;
 
 Q_DECLARE_METATYPE( mygpo::DevicePtr );
 
-#endif //DEVICE_H
+#endif //LIBMYGPO_QT_DEVICE_H

--- a/src/DeviceList.h
+++ b/src/DeviceList.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef DEVICELIST_H
-#define DEVICELIST_H
+#ifndef LIBMYGPO_QT_DEVICELIST_H
+#define LIBMYGPO_QT_DEVICELIST_H
 
 #include <QNetworkReply>
 #include <QSharedPointer>
@@ -65,4 +65,4 @@ typedef QSharedPointer<DeviceList> DeviceListPtr;
 
 Q_DECLARE_METATYPE( mygpo::DeviceListPtr );
 
-#endif //DEVICELIST_H
+#endif //LIBMYGPO_QT_DEVICELIST_H

--- a/src/DeviceSyncResult.h
+++ b/src/DeviceSyncResult.h
@@ -18,8 +18,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef DEVICESYNCRESULT_H
-#define DEVICESYNCRESULT_H
+#ifndef LIBMYGPO_QT_DEVICESYNCRESULT_H
+#define LIBMYGPO_QT_DEVICESYNCRESULT_H
 
 #include <QNetworkReply>
 #include <QObject>
@@ -63,4 +63,4 @@ typedef QSharedPointer<DeviceSyncResult> DeviceSyncResultPtr;
 
 }
 
-#endif // DEVICESYNCRESULT_H
+#endif // LIBMYGPO_QT_DEVICESYNCRESULT_H

--- a/src/DeviceUpdates.h
+++ b/src/DeviceUpdates.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef DEVICEUPDATES_H
-#define DEVICEUPDATES_H
+#ifndef LIBMYGPO_QT_DEVICEUPDATES_H
+#define LIBMYGPO_QT_DEVICEUPDATES_H
 
 #include <QNetworkReply>
 #include <QUrl>
@@ -69,4 +69,4 @@ typedef QSharedPointer<DeviceUpdates> DeviceUpdatesPtr;
 
 }
 
-#endif // DEVICEUPDATES_H
+#endif // LIBMYGPO_QT_DEVICEUPDATES_H

--- a/src/Episode.h
+++ b/src/Episode.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef EPISODE_H
-#define EPISODE_H
+#ifndef LIBMYGPO_QT_EPISODE_H
+#define LIBMYGPO_QT_EPISODE_H
 
 #include <QObject>
 #include <QUrl>
@@ -93,4 +93,4 @@ typedef QSharedPointer<Episode> EpisodePtr;
 
 Q_DECLARE_METATYPE( mygpo::EpisodePtr );
 
-#endif // EPISODE_H
+#endif // LIBMYGPO_QT_EPISODE_H

--- a/src/EpisodeAction.h
+++ b/src/EpisodeAction.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef EPISODEACTION_H
-#define EPISODEACTION_H
+#ifndef LIBMYGPO_QT_EPISODEACTION_H
+#define LIBMYGPO_QT_EPISODEACTION_H
 
 #include <QUrl>
 #include <QString>
@@ -75,4 +75,4 @@ typedef QSharedPointer<EpisodeAction> EpisodeActionPtr;
 
 Q_DECLARE_METATYPE( mygpo::EpisodeActionPtr );
 
-#endif // EPISODEACTION_H
+#endif // LIBMYGPO_QT_EPISODEACTION_H

--- a/src/EpisodeActionList.h
+++ b/src/EpisodeActionList.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef EPISODEACTIONLIST_H
-#define EPISODEACTIONLIST_H
+#ifndef LIBMYGPO_QT_EPISODEACTIONLIST_H
+#define LIBMYGPO_QT_EPISODEACTIONLIST_H
 
 #include "EpisodeAction.h"
 #include "mygpo_export.h"
@@ -68,4 +68,4 @@ typedef QSharedPointer<EpisodeActionList> EpisodeActionListPtr;
 
 Q_DECLARE_METATYPE( mygpo::EpisodeActionListPtr );
 
-#endif // EPISODEACTIONLIST_H
+#endif // LIBMYGPO_QT_EPISODEACTIONLIST_H

--- a/src/EpisodeList.h
+++ b/src/EpisodeList.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef EPISODELIST_H
-#define EPISODELIST_H
+#ifndef LIBMYGPO_QT_EPISODELIST_H
+#define LIBMYGPO_QT_EPISODELIST_H
 
 #include "mygpo_export.h"
 #include "Episode.h"
@@ -63,4 +63,4 @@ typedef QSharedPointer<EpisodeList> EpisodeListPtr;
 
 }
 
-#endif // EPISODELIST_H
+#endif // LIBMYGPO_QT_EPISODELIST_H

--- a/src/JsonCreator.h
+++ b/src/JsonCreator.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef JSONPARSER_H
-#define JSONPARSER_H
+#ifndef LIBMYGPO_QT_JSONPARSER_H
+#define LIBMYGPO_QT_JSONPARSER_H
 
 #include <QByteArray>
 #include <QVariant>
@@ -53,4 +53,4 @@ private:
 
 }
 
-#endif // JSONPARSER_H
+#endif // LIBMYGPO_QT_JSONPARSER_H

--- a/src/Podcast.h
+++ b/src/Podcast.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef PODCAST_H
-#define PODCAST_H
+#ifndef LIBMYGPO_QT_PODCAST_H
+#define LIBMYGPO_QT_PODCAST_H
 
 #include <QUrl>
 #include <QString>
@@ -81,4 +81,4 @@ typedef QSharedPointer<Podcast> PodcastPtr;
 
 Q_DECLARE_METATYPE( mygpo::PodcastPtr );
 
-#endif // PODCAST_H
+#endif // LIBMYGPO_QT_PODCAST_H

--- a/src/PodcastList.h
+++ b/src/PodcastList.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef PODCASTLIST_H
-#define PODCASTLIST_H
+#ifndef LIBMYGPO_QT_PODCASTLIST_H
+#define LIBMYGPO_QT_PODCASTLIST_H
 
 #include "Podcast.h"
 #include "mygpo_export.h"
@@ -64,4 +64,4 @@ typedef QSharedPointer<PodcastList> PodcastListPtr;
 
 }
 
-#endif // PODCASTLIST_H
+#endif // LIBMYGPO_QT_PODCASTLIST_H

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef REQUESTHANDLER_H_
-#define REQUESTHANDLER_H_
+#ifndef LIBMYGPO_QT_REQUESTHANDLER_H_
+#define LIBMYGPO_QT_REQUESTHANDLER_H_
 
 #include "mygpo_export.h"
 
@@ -82,4 +82,4 @@ private:
 
 }
 
-#endif /* REQUESTHANDLER_H_ */
+#endif /* LIBMYGPO_QT_REQUESTHANDLER_H_ */

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef SETTINGS_H
-#define SETTINGS_H
+#ifndef LIBMYGPO_QT_SETTINGS_H
+#define LIBMYGPO_QT_SETTINGS_H
 
 #include <QSharedPointer>
 #include <QMap>
@@ -63,4 +63,4 @@ typedef QSharedPointer<Settings> SettingsPtr;
 
 }
 
-#endif // SETTINGS_H
+#endif // LIBMYGPO_QT_SETTINGS_H

--- a/src/Tag.h
+++ b/src/Tag.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef TAG_H
-#define TAG_H
+#ifndef LIBMYGPO_QT_TAG_H
+#define LIBMYGPO_QT_TAG_H
 
 #include "mygpo_export.h"
 
@@ -56,4 +56,4 @@ typedef QSharedPointer<Tag> TagPtr;
 
 Q_DECLARE_METATYPE( mygpo::TagPtr );
 
-#endif // TAG_H
+#endif // LIBMYGPO_QT_TAG_H

--- a/src/TagList.h
+++ b/src/TagList.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef TAGLIST_H
-#define TAGLIST_H
+#ifndef LIBMYGPO_QT_TAGLIST_H
+#define LIBMYGPO_QT_TAGLIST_H
 
 #include "Tag.h"
 #include "mygpo_export.h"
@@ -63,4 +63,4 @@ typedef QSharedPointer<TagList> TagListPtr;
 
 Q_DECLARE_METATYPE( mygpo::TagListPtr );
 
-#endif // TAGLIST_H
+#endif // LIBMYGPO_QT_TAGLIST_H

--- a/src/UrlBuilder.h
+++ b/src/UrlBuilder.h
@@ -20,8 +20,8 @@
 * USA                                                                      *
 ***************************************************************************/
 
-#ifndef URLBUILDER_H
-#define URLBUILDER_H
+#ifndef LIBMYGPO_QT_URLBUILDER_H
+#define LIBMYGPO_QT_URLBUILDER_H
 
 #include <QString>
 
@@ -143,4 +143,4 @@ private:
 };
 }
 
-#endif // URLBUILDER_H
+#endif // LIBMYGPO_QT_URLBUILDER_H


### PR DESCRIPTION
The include guards in public header files, such as #define PODCAST_H, are quite generic and can easily conflict with include guards in other code that uses libmygpo-qt.  This patch adds a prefix to each #define to reduce the chance of conflicts.
