### PR TITLE
Set the Version field properly in the pkgconfig file.

### DIFF
--- a/libmygpo-qt.pc.in
+++ b/libmygpo-qt.pc.in
@@ -6,7 +6,7 @@ includedir=@INCLUDE_INSTALL_DIR@
 Name: libmygpo-qt
 Description: libmygpo-qt is a C++/Qt Library that wraps the gpodder.net WebAPI
 URL: http://wiki.gpodder.org/wiki/Libmygpo-qt
-Version: @MYGPO_LIB_VERSION@
+Version: @MYGPO_QT_VERSION@
 Requires: QtCore QtNetwork
 Requires.private: QJson
 Libs: -L${libdir} -lmygpo-qt


### PR DESCRIPTION
The libmygpo-qt.pc.in currently tries to use an undefined CMake variable "MYGPO_LIB_VERSION".  Since this Version field is empty in the pkgconfig file, Clementine can't conditionally use a >=1.0.6 system installation of libmygpo-qt.

This patch changes the libmygpo-qt.pc.in to use the actual variable "MYGPO_QT_VERSION".
