### PR TITLE
Support QJson 0.7 (still used in Precise)

### DIFF
--- a/src/qjsonwrapper/Json.cpp
+++ b/src/qjsonwrapper/Json.cpp
@@ -116,7 +116,12 @@ toJson( const QVariant &variant, bool* ok )
     return doc.toJson( QJsonDocument::Compact );
 #else
     QJson::Serializer serializer;
-    return serializer.serialize( variant, ok );
+    QByteArray ret = serializer.serialize(variant);
+    if ( ok != NULL )
+    {
+        *ok = !ret.isNull();
+    }
+    return ret;
 #endif
 }
 


### PR DESCRIPTION
This version lacks a QJson::Serializer::serialize(const QVariant&, bool*),
so emulate it by checking whether the returned QByteArray isNull.

http://buildbot.clementine-player.org/builders/Ubuntu%20Precise%2064-bit/builds/68/steps/compile/logs/stdio