### PR TITLE
[FIX] Use strict QUrl parsing

### DIFF
--- a/src/Podcast.cpp
+++ b/src/Podcast.cpp
@@ -145,9 +145,12 @@ bool PodcastPrivate::parse( const QVariant& data )
         return false;
     QVariantMap podcastMap = data.toMap();
     QVariant v = podcastMap.value( QLatin1String( "url" ) );
-    if ( !v.canConvert( QVariant::Url ) )
+    if ( !v.canConvert( QVariant::ByteArray ) )
         return false;
-    m_url = v.toUrl();
+    m_url = QUrl::fromEncoded(v.toByteArray(), QUrl::StrictMode);
+    if (!m_url.isValid()) { 
+        return false;
+    }
     v = podcastMap.value( QLatin1String( "title" ) );
     if ( !v.canConvert( QVariant::String ) )
         return false;


### PR DESCRIPTION
Use strict QUrl parsing, otherwise the already encoded URI from gpodder.net might get encoded again

Fixes e.g. subscriptions to https://gpodder.net/podcast/taglich-pop-in-swr3-swr3de
