### PR TITLE
Set Qt suffix for target file names in Mygpo-qtConfig.cmake.in

### DIFF
--- a/Mygpo-qtConfig.cmake.in
+++ b/Mygpo-qtConfig.cmake.in
@@ -14,5 +14,5 @@ set(LIBMYGPO_QT_INCLUDE_DIRS "@INCLUDE_INSTALL_DIR@")
 include(${myDir}/Mygpo-qt@MYGPO_QT_VERSION_SUFFIX@Targets.cmake)
 
 # set the expected library variable
-set(LIBMYGPO_QT_LIBRARIES mygpo-qt )
+set(LIBMYGPO_QT_LIBRARIES mygpo-qt@MYGPO_QT_VERSION_SUFFIX@ )
 set(LIBMYGPO_QT_FOUND "True")

--- a/Mygpo-qtConfig.cmake.in
+++ b/Mygpo-qtConfig.cmake.in
@@ -11,7 +11,7 @@ set(MYGPO_QT_VERSION ${MYGPO_QT_VERSION_MAJOR}.${MYGPO_QT_VERSION_MINOR}.${MYGPO
 set(LIBMYGPO_QT_INCLUDE_DIRS "@INCLUDE_INSTALL_DIR@")
 
 # import the exported targets
-include(${myDir}/Mygpo-qtTargets.cmake)
+include(${myDir}/Mygpo-qt@MYGPO_QT_VERSION_SUFFIX@Targets.cmake)
 
 # set the expected library variable
 set(LIBMYGPO_QT_LIBRARIES mygpo-qt )


### PR DESCRIPTION
I needed to do this in order for cmake to find the qt5 version of the target files.