### PR TITLE
Also use Qt version suffix for CMAKECONFIG_INSTALL_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ set(LIB_SUFFIX "" CACHE STRING "The directories where to install libraries to")
 set(LIB_INSTALL_DIR lib${LIB_SUFFIX} )
 set(LIB_DIR_PKGCONF "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}")
 set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include/mygpo-qt${MYGPO_QT_VERSION_SUFFIX}" CACHE PATH "The directory the headers are installed in")
-set(CMAKECONFIG_INSTALL_DIR ${LIB_INSTALL_DIR}/cmake/mygpo-qt )
+set(CMAKECONFIG_INSTALL_DIR ${LIB_INSTALL_DIR}/cmake/mygpo-qt${MYGPO_QT_VERSION_SUFFIX})
 
 if( APPLE )
     set( CPACK_GENERATOR "DragNDrop" )


### PR DESCRIPTION
Otherwise cmake can't find it. Apparently the name of the config
file has to case-insensitively match the name of the dir it's
installed into. While the documentation [1] contains "<name>*" when
listing possible locations, indicating that globbing might happen, it
states a bit below "In all cases the <name> is treated as
case-insensitive and *corresponds* to any of the names specified
(<package> or names given by NAMES)".

[1] https://cmake.org/cmake/help/v3.10/command/find_package.html