### PR TITLE
Update the minimum required cmake version to 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.9 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
 
 project( libmygpo-qt )
 


### PR DESCRIPTION
Get's rid of the following warning:
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.

```

Version 3.0 was released in 2014, so it should be fine.
