### PR TITLE
Fix parsing of timestamp for EpisodeAction

### DIFF
--- a/src/EpisodeAction.cpp
+++ b/src/EpisodeAction.cpp
@@ -118,7 +118,10 @@ bool EpisodeActionPrivate::parse( const QVariant& data )
     if( episodeActionMap.contains( QLatin1String( "timestamp" ) ) )
     {
         s = episodeActionMap.value( QLatin1String( "timestamp" ) );
-        m_timestamp = s.toULongLong();
+        // timestamp is provided in ISO 8601 format, to be converted to qulonglong
+        // when the server generates the timestamp, it will contain extra
+        // sub-second resolution, which we need to cut off first before converting
+        m_timestamp = static_cast<qulonglong>(QDateTime::fromString(s.toString().section(QLatin1String("."), 0, 0), QLatin1String("yyyy-MM-dd'T'hh:mm:ss")).toMSecsSinceEpoch() / 1000);
     }
     else
     {

--- a/src/JsonCreator.cpp
+++ b/src/JsonCreator.cpp
@@ -192,7 +192,7 @@ QVariantMap JsonCreator::episodeActionToQVariantMap( const EpisodeActionPtr epis
         time.addMSecs(episodeAction->timestamp() % 1000 );
         dateTime.setTime(time);
 #endif
-        map.insert( QLatin1String( "timestamp" ), dateTime.toString(Qt::ISODate) );
+        map.insert( QLatin1String( "timestamp" ), dateTime.toUTC().toString(Qt::ISODate) );
     }
     if( actionType == EpisodeAction::Play )
     {


### PR DESCRIPTION
I don't know the entire history of the API, but the current timestamp
that is returned by gpodder.net is in ISO 8601 format.  The libmygpo-qt
implementation was trying to convert this string directly into
qulonglong which would fail, and therefore always return 0.
Presumably, the timestamp was previously returned as seconds-since-epoch,
but changed at some point in time.