### PR TITLE
Fix removeList of DeviceUpdates

### DIFF
--- a/src/DeviceUpdates.cpp
+++ b/src/DeviceUpdates.cpp
@@ -93,7 +93,7 @@ bool DeviceUpdatesPrivate::parse( const QVariant& data )
         return false;
     QVariantMap varMap = data.toMap();
     m_add = varMap.value( QLatin1String( "add" ) );
-    m_remove = varMap.value( QLatin1String( "remove" ) );
+    m_remove = varMap.value( QLatin1String( "rem" ) );
     m_update = varMap.value( QLatin1String( "updates" ) );
     if( varMap.value( QLatin1String( "timestamp" ) ).canConvert( QVariant::LongLong ) )
         m_timestamp = varMap.value( QLatin1String( "timestamp" ) ).toLongLong();


### PR DESCRIPTION
The gpodder.net server returns the list of subscriptions to be removed
under the "rem" tag, not "remove" as the API documentation seems to
suggest.  Hence, libmygpo-qt is not picking up any subscription
removals.

As reference, see gpodder.net server source code (line 73):
https://github.com/gpodder/mygpo/blob/master/mygpo/api/advanced/updates.py