### PR TITLE
Code compatibility updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.5 FATAL_ERROR )
 
 project( libmygpo-qt )
 

--- a/src/AddRemoveResult.h
+++ b/src/AddRemoveResult.h
@@ -52,7 +52,7 @@ private:
     Q_DISABLE_COPY( AddRemoveResult )
     AddRemoveResultPrivate* const d;
     friend class AddRemoveResultPrivate;
-signals:
+Q_SIGNALS:
     /**Gets emitted when the data is ready to read*/
     void finished();
     /**Gets emitted when an parse error ocurred*/

--- a/src/AddRemoveResult_p.h
+++ b/src/AddRemoveResult_p.h
@@ -49,7 +49,7 @@ private:
 
     bool parse( const QVariant& data );
     bool parse( const QByteArray& data );
-private slots:
+private Q_SLOTS:
     void parseData();
     void error( QNetworkReply::NetworkError error );
 };

--- a/src/DeviceList.h
+++ b/src/DeviceList.h
@@ -49,7 +49,7 @@ private:
     Q_DISABLE_COPY( DeviceList )
     DeviceListPrivate* const d;
     friend class DeviceListPrivate;
-signals:
+Q_SIGNALS:
     /**Gets emitted when the data is ready to read*/
     void finished();
     /**Gets emitted when an parse error ocurred*/

--- a/src/DeviceList_p.h
+++ b/src/DeviceList_p.h
@@ -47,7 +47,7 @@ private:
     bool parse( const QVariant& data );
     bool parse( const QByteArray& data );
 
-private slots:
+private Q_SLOTS:
     void parseData();
     void error( QNetworkReply::NetworkError error );
 };

--- a/src/DeviceSyncResult.h
+++ b/src/DeviceSyncResult.h
@@ -50,7 +50,7 @@ private:
     Q_DISABLE_COPY( DeviceSyncResult )
     DeviceSyncResultPrivate* const d;
     friend class DeviceSyncResultPrivate;
-signals:
+Q_SIGNALS:
     /**Gets emitted when the data is ready to read*/
     void finished();
     /**Gets emitted when an parse error ocurred*/

--- a/src/DeviceSyncResult_p.h
+++ b/src/DeviceSyncResult_p.h
@@ -47,7 +47,7 @@ private:
 
     bool parse( const QVariant& data );
     bool parse( const QByteArray& data );
-private slots:
+private Q_SLOTS:
     void parseData();
     void error( QNetworkReply::NetworkError error );
 

--- a/src/DeviceUpdates.h
+++ b/src/DeviceUpdates.h
@@ -56,7 +56,7 @@ private:
     Q_DISABLE_COPY( DeviceUpdates )
     DeviceUpdatesPrivate* const d;
     friend class DeviceUpdatesPrivate;
-signals:
+Q_SIGNALS:
     /**Gets emitted when the data is ready to read*/
     void finished();
     /**Gets emitted when an parse error ocurred*/

--- a/src/DeviceUpdates_p.h
+++ b/src/DeviceUpdates_p.h
@@ -56,7 +56,7 @@ private:
     bool parse( const QVariant& data );
     bool parse( const QByteArray& data );
 
-private slots:
+private Q_SLOTS:
     void parseData();
     void error( QNetworkReply::NetworkError error );
 

--- a/src/Episode.h
+++ b/src/Episode.h
@@ -77,7 +77,7 @@ private:
     Q_DISABLE_COPY( Episode )
     EpisodePrivate* const d;
     friend class EpisodePrivate;
-signals:
+Q_SIGNALS:
     /**Gets emitted when the data is ready to read*/
     void finished();
     /**Gets emitted when an parse error ocurred*/

--- a/src/EpisodeAction.cpp
+++ b/src/EpisodeAction.cpp
@@ -26,7 +26,7 @@
 
 using namespace mygpo;
 
-static qulonglong c_maxlonglong = (2^64)-1;
+static qulonglong c_maxlonglong = ULLONG_MAX;
 
 EpisodeActionPrivate::EpisodeActionPrivate( EpisodeAction* qq, const QVariant& variant, QObject* parent ) : QObject( parent ), q( qq )
 {

--- a/src/EpisodeActionList.h
+++ b/src/EpisodeActionList.h
@@ -52,7 +52,7 @@ public:
 private:
     EpisodeActionListPrivate* const d;
     friend class EpisodeActionListPrivate;
-signals:
+Q_SIGNALS:
     /**Gets emitted when the data is ready to read*/
     void finished();
     /**Gets emitted when an parse error ocurred*/

--- a/src/EpisodeActionList_p.h
+++ b/src/EpisodeActionList_p.h
@@ -50,7 +50,7 @@ private:
     bool parse( const QVariant& data );
     bool parse( const QByteArray& data );
 
-private slots:
+private Q_SLOTS:
     void parseData();
     void error( QNetworkReply::NetworkError error );
 

--- a/src/EpisodeList.h
+++ b/src/EpisodeList.h
@@ -49,7 +49,7 @@ public:
 private:
     EpisodeListPrivate* const d;
     friend class EpisodeListPrivate;
-signals:
+Q_SIGNALS:
     /**Gets emitted when the data is ready to read*/
     void finished();
     /**Gets emitted when an parse error ocurred*/

--- a/src/EpisodeList_p.h
+++ b/src/EpisodeList_p.h
@@ -46,7 +46,7 @@ private:
     bool parse( const QVariant& data );
     bool parse( const QByteArray& data );
 
-private slots:
+private Q_SLOTS:
     void parseData();
     void error( QNetworkReply::NetworkError error );
 

--- a/src/Episode_p.h
+++ b/src/Episode_p.h
@@ -60,7 +60,7 @@ private:
     QNetworkReply::NetworkError m_error;
     bool parse ( const QVariant& data );
     bool parse ( const QByteArray& data );
-private slots:
+private Q_SLOTS:
     void parseData();
     void error ( QNetworkReply::NetworkError error );
 

--- a/src/JsonCreator.cpp
+++ b/src/JsonCreator.cpp
@@ -32,7 +32,7 @@
 
 using namespace mygpo;
 
-static qulonglong c_maxlonglong = (2^64)-1;
+static qulonglong c_maxlonglong = ULLONG_MAX;
 
 QByteArray JsonCreator::addRemoveSubsToJSON( const QList< QUrl >& add, const QList< QUrl >& remove )
 {

--- a/src/Podcast.h
+++ b/src/Podcast.h
@@ -66,7 +66,7 @@ private:
     PodcastPrivate* const d;
     friend class PodcastPrivate;
     bool m_copy;		//true if this object was created by the copy-ctor
-signals:
+Q_SIGNALS:
     /**Gets emitted when the data is ready to read*/
     void finished();
     /**Gets emitted when an parse error ocurred*/

--- a/src/PodcastList.h
+++ b/src/PodcastList.h
@@ -50,7 +50,7 @@ private:
     PodcastListPrivate* const d;
     friend class PodcastListPrivate;
 
-signals:
+Q_SIGNALS:
     /**Gets emitted when the data is ready to read*/
     void finished();
     /**Gets emitted when an parse error ocurred*/

--- a/src/PodcastList_p.h
+++ b/src/PodcastList_p.h
@@ -45,7 +45,7 @@ private:
 
     bool parse( const QVariant& data );
     bool parse( const QByteArray& data );
-private slots:
+private Q_SLOTS:
     void parseData();
     void error( QNetworkReply::NetworkError error );
 };

--- a/src/Podcast_p.h
+++ b/src/Podcast_p.h
@@ -61,7 +61,7 @@ private:
 
     bool parse( const QVariant& data );
     bool parse( const QByteArray& data );
-private slots:
+private Q_SLOTS:
     void parseData();
     void error( QNetworkReply::NetworkError error );
 };

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -50,7 +50,7 @@ private:
     Q_DISABLE_COPY( Settings )
     SettingsPrivate* d;
     friend class SettingsPrivate;
-signals:
+Q_SIGNALS:
     /**Gets emitted when the data is ready to read*/
     void finished();
     /**Gets emitted when an parse error ocurred*/

--- a/src/Settings_p.h
+++ b/src/Settings_p.h
@@ -47,7 +47,7 @@ private:
     bool parse( const QVariant& data );
     bool parse( const QByteArray& data );
 
-private slots:
+private Q_SLOTS:
     void parseData();
     void error( QNetworkReply::NetworkError error );
 

--- a/src/TagList.h
+++ b/src/TagList.h
@@ -48,7 +48,7 @@ private:
     Q_DISABLE_COPY( TagList )
     TagListPrivate* const d;
     friend class TagListPrivate;
-signals:
+Q_SIGNALS:
     /**Gets emitted when the data is ready to read*/
     void finished();
     /**Gets emitted when an parse error ocurred*/

--- a/src/TagList_p.h
+++ b/src/TagList_p.h
@@ -46,7 +46,7 @@ private:
 
     bool parse( const QVariant& data );
     bool parse( const QByteArray& data );
-private slots:
+private Q_SLOTS:
     void parseData();
     void error( QNetworkReply::NetworkError error );
 };

--- a/tests/JsonCreatorTest.h
+++ b/tests/JsonCreatorTest.h
@@ -36,7 +36,7 @@ class JsonCreatorTest : public QObject {
 public:
   JsonCreatorTest();
   virtual ~JsonCreatorTest();
-private slots:
+private Q_SLOTS:
   void initTestCase();
   void cleanupTestCase();
   void init();

--- a/tests/UrlBuilderTest.h
+++ b/tests/UrlBuilderTest.h
@@ -36,7 +36,7 @@ class UrlBuilderTest : public QObject {
 public:
   UrlBuilderTest();
   virtual ~UrlBuilderTest();
-private slots:
+private Q_SLOTS:
   void initTestCase();
   void cleanupTestCase();
   void init();


### PR DESCRIPTION
Some small updates to avoid warnings and make possible to include in projects with KDE Frameworks 5.85+ with default settings (`/usr/include/mygpo-qt5/AddRemoveResult.h:55:1: error: ‘signals’ does not name a type` etc., fixed by converting to Q_SIGNALS and Q_SLOTS)

Also fixes #21 